### PR TITLE
修复“拍摄记录”数据显示问题

### DIFF
--- a/mmsoa/application/views/view_filming.php
+++ b/mmsoa/application/views/view_filming.php
@@ -204,7 +204,16 @@
     $(document).ready(function () {
 
         $('.users-dataTable').dataTable({
-            "aaSorting": [[0, "desc"]]
+            "aaSorting": [[0, "desc"]],
+            "columns": [
+                null,
+                null,
+                null,
+                {"width": "20%"},
+                {"width": "20%"},
+                null,
+                null
+            ]
         });
 
         /* Calendar */


### PR DESCRIPTION
将“拍摄名称”、“后期名称”两列的长度固定为20%。